### PR TITLE
changed from Redis to InMemory for self hosting

### DIFF
--- a/telephony.mdx
+++ b/telephony.mdx
@@ -117,9 +117,8 @@ above. To do this,
 ## Requirements
 Please ensure you have the following installed:
 
-1. [Redis](https://redis.io/)
-2. [Ngrok](https://ngrok.com/)
-3. [ffmpeg](https://ffmpeg.org/)
+1. [Ngrok](https://ngrok.com/)
+2. [ffmpeg](https://ffmpeg.org/)
 
 
 ## Environments
@@ -153,9 +152,7 @@ from vocode.streaming.agent.chat_gpt_agent import ChatGPTAgent
 from vocode.streaming.models.agent import ChatGPTAgentConfig, EchoAgentConfig
 from vocode.streaming.models.message import BaseMessage
 from vocode.streaming.models.telephony import TwilioConfig
-from vocode.streaming.telephony.config_manager.redis_config_manager import (
-    RedisConfigManager,
-)
+from vocode.streaming.telephony.config_manager.in_memory_config_manager import InMemoryConfigManager
 from vocode.streaming.telephony.conversation.outbound_call import OutboundCall
 
 from vocode.streaming.telephony.server.base import InboundCallConfig, TelephonyServer
@@ -166,7 +163,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-config_manager = RedisConfigManager()
+config_manager = InMemoryConfigManager()
 
 BASE_URL = "<YOUR BASE URL>"
 


### PR DESCRIPTION
Since there's been more than one instance of people stumbling over Redis implementation for self-hosting, changed self hosting telephony server to rely on InMemoryConfig instead of RedisConfig.